### PR TITLE
Add collect_only flag to runWithReport

### DIFF
--- a/jupyterlab_celltests/tests.py
+++ b/jupyterlab_celltests/tests.py
@@ -337,7 +337,7 @@ def runWithReturn(notebook, executable=None, rules=None):
     return subprocess.check_output(argv)
 
 
-def runWithReport(notebook, executable=None, rules=None):
+def runWithReport(notebook, executable=None, rules=None, collect_only=False):
     tmpd = tempfile.mkdtemp()
     py_file = os.path.join(tmpd, os.path.basename(notebook).replace('.ipynb', '.py'))
     json_file = os.path.join(tmpd, os.path.basename(notebook).replace('.ipynb', '.json'))
@@ -347,6 +347,8 @@ def runWithReport(notebook, executable=None, rules=None):
             f.write(JSON_CONFD)
         executable = executable or [sys.executable, '-m', 'pytest', '-v']
         argv = executable + ['--internal-json-report=' + json_file, py_file]
+        if collect_only:
+            argv.append('--collect-only')
         subprocess.call(argv)
         with open(json_file, 'r') as f:
             s = f.read()

--- a/jupyterlab_celltests/tests.py
+++ b/jupyterlab_celltests/tests.py
@@ -350,10 +350,7 @@ def runWithReport(notebook, executable=None, rules=None):
         subprocess.call(argv)
         with open(json_file, 'r') as f:
             s = f.read()
-            data = json.loads(s)
-            from pprint import pprint
-            pprint(data)
-            raise NotImplementedError('TODO: Parse reports before returning')
+            return json.loads(s)
     finally:
         shutil.rmtree(tmpd)
 


### PR DESCRIPTION
Use to only collect tests, e.g. to introspect which tests exists.

Usage example:
```python
In[]:
from jupyterlab_celltests.tests import runWithReport
report = runWithReport('Untitled.ipynb', collect_only=True)
for r in report['collected_items']:
    print(r['nodeid'])

Out[]:
Untitled.py::TestExtension::test_cell0
Untitled.py::TestExtension::test_cell1
Untitled.py::TestExtension::test_cell2
Untitled.py::TestExtension::test_cell3
Untitled.py::TestExtension::test_cell4
Untitled.py::TestExtension::test_cell_coverage
Untitled.py::TestExtension::test_cells_per_notebook
Untitled.py::TestExtension::test_class_definition_count
Untitled.py::TestExtension::test_function_definition_count
Untitled.py::TestExtension::test_lines_per_cell_0
Untitled.py::TestExtension::test_lines_per_cell_1
Untitled.py::TestExtension::test_lines_per_cell_2
Untitled.py::TestExtension::test_lines_per_cell_3
Untitled.py::TestExtension::test_lines_per_cell_4
```