### PR TITLE
WIP: Clean up how linter gets called.

### DIFF
--- a/jupyterlab_celltests/lint.py
+++ b/jupyterlab_celltests/lint.py
@@ -119,7 +119,7 @@ def run(notebook, executable=None, rules=None):
         try:
             tf = NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf8')
             tf.write(body)
-            tf.close() # for Windows
+            tf.close()
             executable.append(tf.name)
             ret2 = _run_and_capture_utf8(executable)
             msg = ret2.stdout + '\t' + ret2.stderr

--- a/jupyterlab_celltests/lint.py
+++ b/jupyterlab_celltests/lint.py
@@ -116,15 +116,24 @@ def run(notebook, executable=None, rules=None):
     if executable:
         exp = ScriptExporter()
         (body, resources) = exp.from_notebook_node(nb)
-        tf = NamedTemporaryFile(mode='w', suffix='.py', delete=False)
-        tf.write(body)
-        executable.append(tf.name)
-        ret2 = subprocess.run(executable, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        msg = ret2.stdout.decode('ascii') + '\t' + ret2.stderr.decode('asii')
-        ret.append(LintMessage(-1, 'Checking lint:' + msg.strip(), LintType.LINTER, False if msg.strip() else True))
-        os.remove(tf.name)
+        try:
+            tf = NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf8')
+            tf.write(body)
+            tf.close() # for Windows
+            executable.append(tf.name)
+            ret2 = _run_and_capture_utf8(executable)
+            msg = ret2.stdout + '\t' + ret2.stderr
+            ret.append(LintMessage(-1, 'Checking lint:\n' + msg.strip(), LintType.LINTER, False if msg.strip() else True))
+        finally:
+            os.remove(tf.name)
 
     return ret, passed
+
+
+def _run_and_capture_utf8(args):
+    # PYTHONIOENCODING for pyflakes on Windows
+    run_kw = {'env': dict(os.environ, PYTHONIOENCODING='utf8')} if sys.platform == 'win32' else {}
+    return subprocess.run(args, capture_output=True, encoding='utf-8', **run_kw)
 
 
 def runWithReturn(notebook, executable=None, rules=None):
@@ -143,7 +152,7 @@ def runWithHTMLReturn(notebook, executable=None, rules=None):
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
-        raise Exception('Usage:python jupyterlab_celltests.lint <ipynb file>')
+        raise Exception('Usage:python -m jupyterlab_celltests.lint <ipynb file>')
     notebook = sys.argv[1]
     ret, passed = run(notebook, ['flake8', '--ignore=W391'])
     if passed:


### PR DESCRIPTION
### Close generated py script before linting it

Currently, the generated py script could be empty at the time of lint checking (so lint would always pass) because the file hasn't been written to disk:

![Screenshot from 2019-10-22 21-43-30](https://user-images.githubusercontent.com/1929/67330955-0d6ee300-f515-11e9-89af-3c8cf0cb7e38.png)

`test3` and `好` are both undefined names - lint should fail. Calling `close()` on the file before reading it from another process should fix this.

(This might vary by platform. Here I'm on linux. I think on Win the file would always need to be closed anyway or there'll be an error - not sure.)

### Try to fix unicode handling

Currently (assuming the above issue is fixed), if there is unicode in the notebook that appears as lint, the celltests lint check will crash:

![Screenshot from 2019-10-22 20-51-20](https://user-images.githubusercontent.com/1929/67327061-3ee4b000-f50f-11e9-9184-34bc086c7c56.png)

```
[E 20:52:25.061 LabApp] Uncaught exception POST /celltests/lint/run (127.0.0.1)
    HTTPServerRequest(protocol='http', host='localhost:8888', method='POST', uri='/celltests/lint/run', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/home/sefkw/mc3/envs/miscdev/lib/python3.7/site-packages/tornado/web.py", line 1699, in _execute
        result = await result
      File "/home/sefkw/mc3/envs/miscdev/lib/python3.7/site-packages/tornado/gen.py", line 742, in run
        yielded = self.gen.throw(*exc_info)  # type: ignore
      File "/home/sefkw/code/m/jupyterlab_celltests/jupyterlab_celltests/extension.py", line 73, in post
        ret, status = yield self._run(body, path, name)
      File "/home/sefkw/mc3/envs/miscdev/lib/python3.7/site-packages/tornado/gen.py", line 735, in run
        value = future.result()
      File "/home/sefkw/mc3/envs/miscdev/lib/python3.7/concurrent/futures/thread.py", line 57, in run
        result = self.fn(*self.args, **self.kwargs)
      File "/home/sefkw/code/m/jupyterlab_celltests/jupyterlab_celltests/extension.py", line 64, in _run
        ret, status = runLint(path, executable=self.executable, rules=self.rules)
      File "/home/sefkw/code/m/jupyterlab_celltests/jupyterlab_celltests/lint.py", line 138, in runWithHTMLReturn
        ret_tmp, fail = run(notebook, executable)
      File "/home/sefkw/code/m/jupyterlab_celltests/jupyterlab_celltests/lint.py", line 124, in run
        msg = ret2.stdout.decode('ascii') + '\t' + ret2.stderr.decode('asii')
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 152: ordinal not in range(128)
[E 20:52:25.064 LabApp] {
      "Host": "localhost:8888",
[...]
    }
[E 20:52:25.064 LabApp] 500 POST /celltests/lint/run (127.0.0.1) 375.50ms referer=http://localhost:8888/lab
```

I think it's not safe to do `decode('ascii')` on OS level bytes. 

Additionally, there is a typo for stderr decode() (`asii` rather than `ascii`) that would show up if there were any stderr.

I'm not sure of the right way to handle this for all pythons on all platforms. What I have done here is:
  * create the python script using utf8 (since notebooks are utf8)
  * use `encoding='utf8'` in the `subprocess.run()` call (to get back text rather than bytes).

From previous experience, I believe on Windows it's further necessary to do something like set `PYTHONIOENCODING=utf8` for pyflakes to work with utf8, but I have not tested that here yet. 

### Results from this PR

With the changes in this PR, the above two problems are fixed:

![Screenshot from 2019-10-22 21-03-30](https://user-images.githubusercontent.com/1929/67330539-6e49eb80-f514-11e9-9bd2-aa01e4d422b0.png)

Only tested on linux so far though.

Have also modified the lint block so that temporary files are not left around if there's a failure.
