### PR TITLE
Clean up packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ python:
 
 install:
     - pip install -r requirements.txt
-    - pip install -U pytest pytest-cov flake8 pylint codecov pandas cufflinks
+    # pandas and cufflinks could be added as test dependencies in setup.py
+    - pip install -U codecov pandas cufflinks
     - yarn
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.6"
 
 install:
-    - pip install -r requirements.txt
+    - pip install -e .[dev]
     # pandas and cufflinks could be added as test dependencies in setup.py
     - pip install -U codecov pandas cufflinks
     - yarn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,9 @@ If you want to help resolve an issue by making some changes that are larger than
 - Run the following commands inside the cloned repository:
   - `pip install -e .[dev]` - This will install the Python package in development
     mode.
-  - `jupyter labextension install .` - This will add the lab extension development
+  - `jupyter labextension install .` - This will add the lab extension in development
     mode.
+  - `jupyter serverextension enable --py jupyterlab_celltests` - This will enable the server extension.
 - Validate the install by running the tests:
   - `py.test` - This command will run the Python tests.
   - `npm test` - This command will run the JS tests.

--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ Checking classes per notebook <= 10:    PASSED
 Checking cell test coverage >= 50:  PASSED
 ```
 
+NB: In jupyterlab, notebooks will be lint checked using the version of
+python that is running jupyter lab itself. A notebook intended to be
+run with a Python 2 kernel could therefore generate syntax errors
+during lint checking.

--- a/jupyterlab_celltests/lint.py
+++ b/jupyterlab_celltests/lint.py
@@ -133,7 +133,7 @@ def run(notebook, executable=None, rules=None):
 def _run_and_capture_utf8(args):
     # PYTHONIOENCODING for pyflakes on Windows
     run_kw = {'env': dict(os.environ, PYTHONIOENCODING='utf8')} if sys.platform == 'win32' else {}
-    return subprocess.run(args, capture_output=True, encoding='utf-8', **run_kw)
+    return subprocess.run(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='utf-8', **run_kw)
 
 
 def runWithReturn(notebook, executable=None, rules=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyterlab>=1.0.0
 nbval>=0.9.1
 pytest>=4.4.0
-pytest-cov>=2.6.1
 pytest-html>=1.20.0
+flake8

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,10 @@ from jupyter_packaging import (
 
 pjoin = path.join
 
-ensure_python(('2.7', '>=3.3'))
+# TODO: Isn't jupyterlab_celltests effectively py3 only?
+# E.g. subprocess.run() didn't appear til 3.5, open() didn't get
+# encoding until 3, etc. I haven't tested the change below.
+ensure_python('>=3.5')
 
 name = 'jupyterlab_celltests'
 here = path.abspath(path.dirname(__file__))
@@ -56,14 +59,11 @@ setup(
 
     classifiers=[
         'Development Status :: 3 - Alpha',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',        
         'Framework :: Jupyter',
     ],
 
@@ -73,7 +73,9 @@ setup(
     packages=find_packages(exclude=['tests', ]),
     install_requires=requires,
     extras_require={
-        'dev': ['pytest', 'pytest-cov', 'pylint', 'flake8', 'bumpversion']
+        'dev': ['bumpversion',
+                'pytest-cov >=2.6.1',
+                'mock']
     },
     include_package_data=True,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,7 @@ from jupyter_packaging import (
 
 pjoin = path.join
 
-# TODO: Isn't jupyterlab_celltests effectively py3 only?
-# E.g. subprocess.run() didn't appear til 3.5, open() didn't get
-# encoding until 3, etc. I haven't tested the change below.
-ensure_python('>=3.5')
+ensure_python('>=3.6')
 
 name = 'jupyterlab_celltests'
 here = path.abspath(path.dirname(__file__))
@@ -60,7 +57,6 @@ setup(
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',        


### PR DESCRIPTION
* Added missing dev step (jupyter serverextension enable).

* flake8, pytest, and pytest-html appear to be end-user run dependencies (not just dev dependencies).

* Added missing dev dependency (mock).

* Removed apparently unused dev dependency (pylint).

* Added note about lint checking py2 notebooks.

* Made the minimum python version clearer. 
  * celltests was python 3.5+ only (despite what its packaging says) until #42 was merged, which made it 3.7+ only. 
  * This PR makes the minimum python be 3.6, since it was easy to do. 
  * If it's also not ok to drop 3.5 support yet, I could work around that too (subprocess.run () didn't get the encoding parameter until 3.6). 
  * Things that made celltests be incompatible with py2 and require 3.5+ include that subprocess.run() didn't appear til 3.5, open() didn't get an encoding parameter until 3, etc.

