### PR TITLE
Fix counting of class and function definitions

### DIFF
--- a/jupyterlab_celltests/shared.py
+++ b/jupyterlab_celltests/shared.py
@@ -61,6 +61,7 @@ def extract_extrametadata(notebook, override=None):
         base['classes'] += class_counter.count
 
         for line in c['source'].split('\n'):
+            base['lines'] += 1
             base['cell_lines'][-1] += 1
         for t in c['metadata'].get('tests', []):
             if t.strip().startswith('%cell'):

--- a/jupyterlab_celltests/shared.py
+++ b/jupyterlab_celltests/shared.py
@@ -1,8 +1,27 @@
-# import pytest
-import re
+import ast
 
-FUNCTION_REGEX = r'def (.*?):'
-CLASS_REGEX = r'class (.*?):'
+class FnDefCounter(ast.NodeVisitor):
+    """Counts function definitions (ignoring class methods)."""
+
+    count = 0
+
+    def visit_FunctionDef(self, node):
+        self.count += 1
+
+    def visit_ClassDef(self, node):
+        return
+
+    # to count lambdas, add visit_Lambda
+
+
+class ClassDefCounter(ast.NodeVisitor):
+    """Counts class declarations."""
+
+    count = 0
+
+    def visit_ClassDef(self, node):
+        self.count+=1
+
 
 
 def extract_cellsources(notebook):
@@ -20,12 +39,9 @@ def extract_extrametadata(notebook, override=None):
     base['cell_tested'] = []
     base['test_count'] = 0
     base['cell_lines'] = []
-    base['lines'] = 0
+    base['lines'] = 0 # TODO: is this used?
     base['functions'] = 0
     base['classes'] = 0
-
-    foo_regex = re.compile(FUNCTION_REGEX)
-    class_regex = re.compile(CLASS_REGEX)
 
     for c in notebook.cells:
         if c.get('cell_type') in ('markdown', 'raw',):
@@ -34,13 +50,18 @@ def extract_extrametadata(notebook, override=None):
         base['cell_lines'].append(0)
         base['cell_tested'].append(False)
         base['cell_count'] += 1
+
+        parsed_source = ast.parse(c['source'])
+        fn_def_counter = FnDefCounter()
+        fn_def_counter.visit(parsed_source)
+        base['functions'] += fn_def_counter.count
+
+        class_counter = ClassDefCounter()
+        class_counter.visit(parsed_source)
+        base['classes'] += class_counter.count
+
         for line in c['source'].split('\n'):
-            base['lines'] += 1
             base['cell_lines'][-1] += 1
-            if re.search(foo_regex, line):
-                base['functions'] += 1
-            if re.search(class_regex, line):
-                base['classes'] += 1
         for t in c['metadata'].get('tests', []):
             if t.strip().startswith('%cell'):
                 base['test_count'] += 1

--- a/jupyterlab_celltests/shared.py
+++ b/jupyterlab_celltests/shared.py
@@ -1,5 +1,6 @@
 import ast
 
+
 class FnDefCounter(ast.NodeVisitor):
     """Counts function definitions (ignoring class methods)."""
 
@@ -20,8 +21,7 @@ class ClassDefCounter(ast.NodeVisitor):
     count = 0
 
     def visit_ClassDef(self, node):
-        self.count+=1
-
+        self.count += 1
 
 
 def extract_cellsources(notebook):
@@ -39,7 +39,7 @@ def extract_extrametadata(notebook, override=None):
     base['cell_tested'] = []
     base['test_count'] = 0
     base['cell_lines'] = []
-    base['lines'] = 0 # TODO: is this used?
+    base['lines'] = 0  # TODO: is this used?
     base['functions'] = 0
     base['classes'] = 0
 

--- a/tests/basic.ipynb
+++ b/tests/basic.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f1(x): x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f2(y): y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class X: pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class X(object): pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if x == 2: pass"
+   ]
+  }  
+],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/basic.ipynb
+++ b/tests/basic.ipynb
@@ -44,6 +44,24 @@
    "source": [
     "if x == 2: pass"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "class X(object): pass\n",
+    "class X: pass\n",
+    "def X(object): pass\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "class X(object): pass\n",
+    "class X: pass\n",
+    "def X(object): pass\n"
+   ]
   }  
 ],
  "metadata": {

--- a/tests/more.ipynb
+++ b/tests/more.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "notclass = lambda x: x\n",
-    "if notclass X(object): pass"
+    "if notclass(object): pass"
    ]
   },
   {

--- a/tests/more.ipynb
+++ b/tests/more.ipynb
@@ -45,6 +45,17 @@
     "notclass = lambda x: x\n",
     "if notclass X(object): pass"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "def f(x): pass\n",
+    "\"\"\""
+   ]
   }
 ],
  "metadata": {

--- a/tests/more.ipynb
+++ b/tests/more.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def f1(x): x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# def f2(y): y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class X: pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# class X(object): pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "notclass = lambda x: x\n",
+    "if notclass X(object): pass"
+   ]
+  }
+],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -9,15 +9,32 @@ BASIC_NB = os.path.join(os.path.dirname(__file__), 'basic.ipynb')
 MORE_NB = os.path.join(os.path.dirname(__file__), 'more.ipynb')
 
 
-def test_extract_extrametadata_basic():
-    nb = nbformat.read(BASIC_NB, 4)
-    res = extract_extrametadata(nb)
-    assert res['functions'] == 2
-    assert res['classes'] == 2
+def _metadata(nb, what):
+    extra_metadata = extract_extrametadata(nbformat.read(nb, 4))
+    return extra_metadata[what]
 
 
-def test_extract_extrametadata_more():
-    nb = nbformat.read(MORE_NB, 4)
-    res = extract_extrametadata(nb)
-    assert res['functions'] == 1
-    assert res['classes'] == 1
+def test_extract_extrametadata_functions_basic():
+    assert _metadata(BASIC_NB, 'functions') == 2
+
+def test_extract_extrametadata_classes_basic():
+    assert _metadata(BASIC_NB, 'classes') == 2
+
+def test_extract_extrametadata_cell_count_basic():
+    assert _metadata(BASIC_NB, 'cell_count') == 5
+
+def test_extract_extrametadata_cell_lines_basic():
+    assert _metadata(BASIC_NB, 'cell_lines') == [1]*5
+
+
+def test_extract_extrametadata_functions_more():
+    assert _metadata(MORE_NB, 'functions') == 1
+
+def test_extract_extrametadata_classes_more():
+    assert _metadata(MORE_NB, 'classes') == 1
+
+def test_extract_extrametadata_cell_count_more():
+    assert _metadata(MORE_NB, 'cell_count') == 6
+
+def test_extract_extrametadata_cell_lines_more():
+    assert _metadata(MORE_NB, 'cell_lines') == [1]*4 + [2,3]

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,0 +1,23 @@
+import os
+
+import nbformat
+
+from jupyterlab_celltests.shared import extract_extrametadata
+
+
+BASIC_NB = os.path.join(os.path.dirname(__file__), 'basic.ipynb')
+MORE_NB = os.path.join(os.path.dirname(__file__), 'more.ipynb')
+
+
+def test_extract_extrametadata_basic():
+    nb = nbformat.read(BASIC_NB, 4)
+    res = extract_extrametadata(nb)
+    assert res['functions'] == 2
+    assert res['classes'] == 2
+
+
+def test_extract_extrametadata_more():
+    nb = nbformat.read(MORE_NB, 4)
+    res = extract_extrametadata(nb)
+    assert res['functions'] == 1
+    assert res['classes'] == 1


### PR DESCRIPTION
Currently the class and function definition counting is based on a regex, which can't work in general. Added some basic tests to show where it fails (e.g. things in comments/docstrings, things like `if reclass(x):`, etc), and replaced with ast parsing.
