### PR TITLE
More informative lint messages

### DIFF
--- a/jupyterlab_celltests/lint.py
+++ b/jupyterlab_celltests/lint.py
@@ -22,7 +22,7 @@ def lint_lines_per_cell(lines_per_cell, metadata):
         return [], True
     for i, lines_in_cell in enumerate(metadata.get('cell_lines', [])):
         # TODO: ambiguous - e.g. cell 0 or first cell?
-        ret.append(LintMessage(i+1, 'Checking lines in cell (max={max_}; actual={actual})'.format(max_=lines_per_cell,actual=lines_in_cell), LintType.LINES_PER_CELL, lines_in_cell <= lines_per_cell))
+        ret.append(LintMessage(i+1, 'Checking lines in cell (max={max_}; actual={actual})'.format(max_=lines_per_cell, actual=lines_in_cell), LintType.LINES_PER_CELL, lines_in_cell <= lines_per_cell))
     return ret, all([x.passed for x in ret])
 
 
@@ -31,7 +31,7 @@ def lint_cells_per_notebook(cells_per_notebook, metadata):
         return [], True
     cell_count = metadata.get('cell_count', -1)
     passed = cell_count <= cells_per_notebook
-    return [LintMessage(-1,'Checking cells per notebook (max={max_}; actual={actual})'.format(max_=cells_per_notebook,actual=cell_count),LintType.CELLS_PER_NOTEBOOK, passed)], passed
+    return [LintMessage(-1, 'Checking cells per notebook (max={max_}; actual={actual})'.format(max_=cells_per_notebook, actual=cell_count), LintType.CELLS_PER_NOTEBOOK, passed)], passed
 
 
 def lint_function_definitions(function_definitions, metadata):
@@ -39,7 +39,7 @@ def lint_function_definitions(function_definitions, metadata):
         return [], True
     functions = metadata.get('functions', -1)
     passed = functions <= function_definitions
-    return [LintMessage(-1, 'Checking functions per notebook (max={max_}; actual={actual})'.format(max_=function_definitions,actual=functions), LintType.FUNCTION_DEFINITIONS, passed)], passed
+    return [LintMessage(-1, 'Checking functions per notebook (max={max_}; actual={actual})'.format(max_=function_definitions, actual=functions), LintType.FUNCTION_DEFINITIONS, passed)], passed
 
 
 def lint_class_definitions(class_definitions, metadata):
@@ -47,7 +47,7 @@ def lint_class_definitions(class_definitions, metadata):
         return [], True
     classes = metadata.get('classes', -1)
     passed = classes <= class_definitions
-    return [LintMessage(-1, 'Checking classes per notebook (max={max_}; actual={actual})'.format(max_=class_definitions,actual=classes), LintType.FUNCTION_DEFINITIONS, passed)], passed
+    return [LintMessage(-1, 'Checking classes per notebook (max={max_}; actual={actual})'.format(max_=class_definitions, actual=classes), LintType.FUNCTION_DEFINITIONS, passed)], passed
 
 
 # TODO: I think this isn't lint and should be removed.

--- a/jupyterlab_celltests/lint.py
+++ b/jupyterlab_celltests/lint.py
@@ -22,37 +22,41 @@ def lint_lines_per_cell(lines_per_cell, metadata):
         return [], True
     for i, lines_in_cell in enumerate(metadata.get('cell_lines', [])):
         # TODO: ambiguous - e.g. cell 0 or first cell?
-        ret.append(LintMessage(i+1, 'Checking lines in cell', LintType.LINES_PER_CELL, lines_in_cell <= lines_per_cell))
+        ret.append(LintMessage(i+1, 'Checking lines in cell (max={max_}; actual={actual})'.format(max_=lines_per_cell,actual=lines_in_cell), LintType.LINES_PER_CELL, lines_in_cell <= lines_per_cell))
     return ret, all([x.passed for x in ret])
 
 
 def lint_cells_per_notebook(cells_per_notebook, metadata):
     if cells_per_notebook < 0:
         return [], True
-    passed = metadata.get('cell_count', -1) <= cells_per_notebook
-    return [LintMessage(-1, 'Checking cells per notebook', LintType.CELLS_PER_NOTEBOOK, passed)], passed
+    cell_count = metadata.get('cell_count', -1)
+    passed = cell_count <= cells_per_notebook
+    return [LintMessage(-1,'Checking cells per notebook (max={max_}; actual={actual})'.format(max_=cells_per_notebook,actual=cell_count),LintType.CELLS_PER_NOTEBOOK, passed)], passed
 
 
 def lint_function_definitions(function_definitions, metadata):
     if function_definitions < 0:
         return [], True
-    passed = metadata.get('functions', -1) <= function_definitions
-    return [LintMessage(-1, 'Checking functions per notebook', LintType.FUNCTION_DEFINITIONS, passed)], passed
+    functions = metadata.get('functions', -1)
+    passed = functions <= function_definitions
+    return [LintMessage(-1, 'Checking functions per notebook (max={max_}; actual={actual})'.format(max_=function_definitions,actual=functions), LintType.FUNCTION_DEFINITIONS, passed)], passed
 
 
 def lint_class_definitions(class_definitions, metadata):
     if class_definitions < 0:
         return [], True
-    passed = metadata.get('classes', -1) <= class_definitions
-    return [LintMessage(-1, 'Checking classes per notebook', LintType.FUNCTION_DEFINITIONS, passed)], passed
+    classes = metadata.get('classes', -1)
+    passed = classes <= class_definitions
+    return [LintMessage(-1, 'Checking classes per notebook (max={max_}; actual={actual})'.format(max_=class_definitions,actual=classes), LintType.FUNCTION_DEFINITIONS, passed)], passed
 
 
 # TODO: I think this isn't lint and should be removed.
 def lint_cell_coverage(cell_coverage, metadata):
     if cell_coverage < 0:
         return [], True
-    passed = 100*metadata.get('test_count', 0)/metadata.get('cell_count', -1) >= cell_coverage
-    return [LintMessage(-1, 'Checking cell test coverage', LintType.CELL_COVERAGE, passed)], passed
+    measured_cell_coverage = 100*metadata.get('test_count', 0)/metadata.get('cell_count', -1)
+    passed = measured_cell_coverage >= cell_coverage
+    return [LintMessage(-1, 'Checking cell test coverage (min={min_}; actual={actual})'.format(min_=cell_coverage, actual=measured_cell_coverage), LintType.CELL_COVERAGE, passed)], passed
 
 
 def run(notebook, executable=None, rules=None):


### PR DESCRIPTION
Adds `(max=n; actual=m)` to the message:

```
FAILED: Checking lines in cell (max=1; actual=3) (Cell 1)
PASSED: Checking lines in cell (max=1; actual=1) (Cell 2)
PASSED: Checking lines in cell (max=1; actual=1) (Cell 3)
PASSED: Checking lines in cell (max=1; actual=1) (Cell 4)
PASSED: Checking lines in cell (max=1; actual=1) (Cell 5)
FAILED: Checking cells per notebook (max=3; actual=5) (Notebook)
PASSED: Checking functions per notebook (max=10; actual=1) (Notebook)
PASSED: Checking classes per notebook (max=10; actual=0) (Notebook)
PASSED: Checking cell test coverage (min=50; actual=60.0) (Notebook)
FAILED: Checking lint:
/tmp/tmpv_7t581g.py:11:1: E302 expected 2 blank lines, found 0
/tmp/tmpv_7t581g.py:11:1: E704 multiple statements on one line (def)
/tmp/tmpv_7t581g.py:33:1: F821 undefined name 'test3'
/tmp/tmpv_7t581g.py:33:6: W291 trailing whitespace (Notebook)
```

After doing it, I see the message is now a little bit clumsy (two sets of parentheses), but oh well.