### PR TITLE
Simplify/clarify the lint functions (should be no behavior change).

### DIFF
--- a/jupyterlab_celltests/lint.py
+++ b/jupyterlab_celltests/lint.py
@@ -54,7 +54,7 @@ def lint_cell_coverage(test_count, cell_count, min_cell_coverage=-1):
     """
     Note: cell coverage is expressed as a percentage.
     """
-    if min_cell_coverage < 0:
+    if (min_cell_coverage < 0) or (cell_count == 0):
         return [], True
     measured_cell_coverage = 100 * test_count / cell_count
     passed = measured_cell_coverage >= min_cell_coverage

--- a/jupyterlab_celltests/lint.py
+++ b/jupyterlab_celltests/lint.py
@@ -7,63 +7,58 @@ from tempfile import NamedTemporaryFile
 from .shared import extract_extrametadata
 from .define import LintMessage, LintType
 
-# TODO why do these fns take a parameter that's also present in
-# metadata?  (e.g. lint function take lines_per_cell, but that's
-# already in metadata)
-
 # TODO: there's duplication with tests here. Should both use same
 # underlying code. Also, some of these things are not lint (e.g.
 # test coverage, while some of the tests are really just lint).
 
 
-def lint_lines_per_cell(lines_per_cell, metadata):
+def lint_lines_per_cell(cell_lines, max_lines_per_cell=-1):
     ret = []
-    if lines_per_cell < 0:
+    if max_lines_per_cell < 0:
         return [], True
-    for i, lines_in_cell in enumerate(metadata.get('cell_lines', [])):
-        # TODO: ambiguous - e.g. cell 0 or first cell?
+    for i, lines_in_cell in enumerate(cell_lines):        
         ret.append(
             LintMessage(
-                i + 1,
+                i + 1,  # TODO: ambiguous - e.g. cell 0 or first cell?
                 'Checking lines in cell (max={max_}; actual={actual})'.format(
-                    max_=lines_per_cell,
+                    max_=max_lines_per_cell,
                     actual=lines_in_cell),
                 LintType.LINES_PER_CELL,
-                lines_in_cell <= lines_per_cell))
+                lines_in_cell <= max_lines_per_cell))
     return ret, all([x.passed for x in ret])
 
 
-def lint_cells_per_notebook(cells_per_notebook, metadata):
-    if cells_per_notebook < 0:
+def lint_cells_per_notebook(cell_count, max_cells_per_notebook=-1):
+    if max_cells_per_notebook < 0:
         return [], True
-    cell_count = metadata.get('cell_count', -1)
-    passed = cell_count <= cells_per_notebook
-    return [LintMessage(-1, 'Checking cells per notebook (max={max_}; actual={actual})'.format(max_=cells_per_notebook, actual=cell_count), LintType.CELLS_PER_NOTEBOOK, passed)], passed
+    passed = cell_count <= max_cells_per_notebook
+    return [LintMessage(-1, 'Checking cells per notebook (max={max_}; actual={actual})'.format(max_=max_cells_per_notebook, actual=cell_count), LintType.CELLS_PER_NOTEBOOK, passed)], passed
 
 
-def lint_function_definitions(function_definitions, metadata):
-    if function_definitions < 0:
+def lint_function_definitions(functions, max_function_definitions=-1):
+    if max_function_definitions < 0:
         return [], True
-    functions = metadata.get('functions', -1)
-    passed = functions <= function_definitions
-    return [LintMessage(-1, 'Checking functions per notebook (max={max_}; actual={actual})'.format(max_=function_definitions, actual=functions), LintType.FUNCTION_DEFINITIONS, passed)], passed
+    passed = functions <= max_function_definitions
+    return [LintMessage(-1, 'Checking functions per notebook (max={max_}; actual={actual})'.format(max_=max_function_definitions, actual=functions), LintType.FUNCTION_DEFINITIONS, passed)], passed
 
 
-def lint_class_definitions(class_definitions, metadata):
-    if class_definitions < 0:
+def lint_class_definitions(classes, max_class_definitions=-1):
+    if max_class_definitions < 0:
         return [], True
-    classes = metadata.get('classes', -1)
-    passed = classes <= class_definitions
-    return [LintMessage(-1, 'Checking classes per notebook (max={max_}; actual={actual})'.format(max_=class_definitions, actual=classes), LintType.FUNCTION_DEFINITIONS, passed)], passed
+    passed = classes <= max_class_definitions
+    return [LintMessage(-1, 'Checking classes per notebook (max={max_}; actual={actual})'.format(max_=max_class_definitions, actual=classes), LintType.FUNCTION_DEFINITIONS, passed)], passed
 
 
 # TODO: I think this isn't lint and should be removed.
-def lint_cell_coverage(cell_coverage, metadata):
-    if cell_coverage < 0:
+def lint_cell_coverage(test_count, cell_count, min_cell_coverage=-1):
+    """
+    Note: cell coverage is expressed as a percentage.
+    """
+    if min_cell_coverage < 0:
         return [], True
-    measured_cell_coverage = 100 * metadata.get('test_count', 0) / metadata.get('cell_count', -1)
-    passed = measured_cell_coverage >= cell_coverage
-    return [LintMessage(-1, 'Checking cell test coverage (min={min_}; actual={actual})'.format(min_=cell_coverage, actual=measured_cell_coverage), LintType.CELL_COVERAGE, passed)], passed
+    measured_cell_coverage = 100 * test_count / cell_count
+    passed = measured_cell_coverage >= min_cell_coverage
+    return [LintMessage(-1, 'Checking cell test coverage (min={min_}; actual={actual})'.format(min_=min_cell_coverage, actual=measured_cell_coverage), LintType.CELL_COVERAGE, passed)], passed
 
 
 def run(notebook, executable=None, rules=None):
@@ -75,33 +70,30 @@ def run(notebook, executable=None, rules=None):
     rules = rules or {}
     extra_metadata.update(rules)
 
+    # TODO: lintfail is more like lintpassed?
+
     if 'lines_per_cell' in extra_metadata:
-        lines_per_cell = extra_metadata.get('lines_per_cell', -1)
-        lintret, lintfail = lint_lines_per_cell(lines_per_cell, extra_metadata)
+        lintret, lintfail = lint_lines_per_cell(extra_metadata['cell_lines'], max_lines_per_cell=extra_metadata['lines_per_cell'])
         ret.extend(lintret)
         passed = passed and lintfail
 
     if 'cells_per_notebook' in extra_metadata:
-        cells_per_notebook = extra_metadata.get('cells_per_notebook', -1)
-        lintret, lintfail = lint_cells_per_notebook(cells_per_notebook, extra_metadata)
+        lintret, lintfail = lint_cells_per_notebook(extra_metadata['cell_count'], max_cells_per_notebook=extra_metadata['cells_per_notebook'])
         ret.extend(lintret)
         passed = passed and lintfail
 
     if 'function_definitions' in extra_metadata:
-        function_definitions = extra_metadata.get('function_definitions', -1)
-        lintret, lintfail = lint_function_definitions(function_definitions, extra_metadata)
+        lintret, lintfail = lint_function_definitions(extra_metadata['functions'], max_function_definitions=extra_metadata['function_definitions'])
         ret.extend(lintret)
         passed = passed and lintfail
 
     if 'class_definitions' in extra_metadata:
-        class_definitions = extra_metadata.get('class_definitions', -1)
-        lintret, lintfail = lint_class_definitions(class_definitions, extra_metadata)
+        lintret, lintfail = lint_class_definitions(extra_metadata['classes'], max_class_definitions=extra_metadata['class_definitions'])
         ret.extend(lintret)
         passed = passed and lintfail
 
     if 'cell_coverage' in extra_metadata:
-        cell_coverage = extra_metadata.get('cell_coverage', 0)
-        lintret, lintfail = lint_cell_coverage(cell_coverage, extra_metadata)
+        lintret, lintfail = lint_cell_coverage(test_count=extra_metadata['test_count'], cell_count=extra_metadata['cell_count'], min_cell_coverage=extra_metadata['cell_coverage'])
         ret.extend(lintret)
         passed = passed and lintfail
 

--- a/jupyterlab_celltests/lint.py
+++ b/jupyterlab_celltests/lint.py
@@ -16,7 +16,7 @@ def lint_lines_per_cell(cell_lines, max_lines_per_cell=-1):
     ret = []
     if max_lines_per_cell < 0:
         return [], True
-    for i, lines_in_cell in enumerate(cell_lines):        
+    for i, lines_in_cell in enumerate(cell_lines):
         ret.append(
             LintMessage(
                 i + 1,  # TODO: ambiguous - e.g. cell 0 or first cell?

--- a/jupyterlab_celltests/shared.py
+++ b/jupyterlab_celltests/shared.py
@@ -32,6 +32,8 @@ def extract_celltests(notebook):
     return [c['metadata'].get('tests', []) for c in notebook.cells]
 
 
+# TODO: I think it's confusing to insert the actual counts into the metadata.
+# Why not keep them separate?
 def extract_extrametadata(notebook, override=None):
     base = notebook.metadata.get('celltests', {})
     override = override or {}

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -69,7 +69,8 @@ def test_lint_class_definitions(max_class_definitions, classes, expected_ret, ex
         ( 0, 10, 50, [False], False),
         ( 5, 10, 50,  [True],  True),
         ( 0, 10,  0,  [True],  True),
-        ( 0, 10, -1,      [],  True)
+        ( 0, 10, -1,      [],  True),
+        ( 0,  0,  0,      [],  True)
     ]
 )
 def test_cell_coverage(test_count, cell_count, min_cell_coverage, expected_ret, expected_pass):

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -11,23 +11,19 @@ class TestLint:
         pass
 
 @pytest.mark.parametrize(
-    "lines_per_cell, cell_lines, expected_ret, expected_pass", [
+    "max_lines_per_cell, cell_lines, expected_ret, expected_pass", [
         ( 3, [0,1,2,3,4], [True, True, True, True,False], False),
         ( 3,   [0,1,2,3],       [True, True, True, True],  True),
-        (-1,       [0,1],                             [],  True), 
+        (-1,       [0,1],                             [],  True),
     ]
 )
-def test_lines_per_cell(lines_per_cell, cell_lines, expected_ret, expected_pass):
-    metadata = {
-        'lines_per_cell': lines_per_cell,
-        'cell_lines': cell_lines,
-    }
-    ret, passed = lint_lines_per_cell(metadata['lines_per_cell'], metadata)
+def test_lines_per_cell(max_lines_per_cell, cell_lines, expected_ret, expected_pass):
+    ret, passed = lint_lines_per_cell(cell_lines, max_lines_per_cell)
     _verify(ret, passed, expected_ret, expected_pass)
 
 
 @pytest.mark.parametrize(
-    "cells_per_notebook, cell_count, expected_ret, expected_pass", [
+    "max_cells_per_notebook, cell_count, expected_ret, expected_pass", [
         ( 5, 10, [False], False),
         ( 5,  3,  [True],  True),
         ( 0, 10, [False], False),
@@ -35,17 +31,13 @@ def test_lines_per_cell(lines_per_cell, cell_lines, expected_ret, expected_pass)
         (-1, 10,      [],  True)
     ]
 )
-def test_cells_per_notebook_bad(cells_per_notebook, cell_count, expected_ret, expected_pass):
-    metadata = {
-        'cells_per_notebook': cells_per_notebook,
-        'cell_count': cell_count
-    }
-    ret, passed = lint_cells_per_notebook(metadata['cells_per_notebook'], metadata)
+def test_cells_per_notebook(max_cells_per_notebook, cell_count, expected_ret, expected_pass):
+    ret, passed = lint_cells_per_notebook(cell_count, max_cells_per_notebook)
     _verify(ret, passed, expected_ret, expected_pass)
 
 
 @pytest.mark.parametrize(
-    "function_definitions, functions, expected_ret, expected_pass", [
+    "max_function_definitions, functions, expected_ret, expected_pass", [
         ( 5, 10, [False], False),
         ( 5,  3,  [True],  True),
         ( 0, 10, [False], False),
@@ -53,17 +45,13 @@ def test_cells_per_notebook_bad(cells_per_notebook, cell_count, expected_ret, ex
         (-1, 10,      [],  True)
     ]
 )
-def test_lint_function_definitions(function_definitions, functions, expected_ret, expected_pass):
-    metadata = {
-        'function_definitions': function_definitions,
-        'functions': functions
-    }
-    ret, passed  = lint_function_definitions(function_definitions, metadata)
+def test_lint_function_definitions(max_function_definitions, functions, expected_ret, expected_pass):
+    ret, passed  = lint_function_definitions(functions, max_function_definitions)
     _verify(ret, passed, expected_ret, expected_pass)
 
 
 @pytest.mark.parametrize(
-    "class_definitions, classes, expected_ret, expected_pass", [
+    "max_class_definitions, classes, expected_ret, expected_pass", [
         ( 5, 10, [False], False),
         ( 5,  3,  [True],  True),
         ( 0, 10, [False], False),
@@ -71,30 +59,21 @@ def test_lint_function_definitions(function_definitions, functions, expected_ret
         (-1, 10,      [],  True)
     ]
 )
-def test_lint_class_definitions(class_definitions, classes, expected_ret, expected_pass):
-    metadata = {
-        'class_definitions': class_definitions,
-        'classes': classes
-    }
-    ret, passed = lint_class_definitions(class_definitions, metadata)
+def test_lint_class_definitions(max_class_definitions, classes, expected_ret, expected_pass):
+    ret, passed = lint_class_definitions(classes, max_class_definitions)
     _verify(ret, passed, expected_ret, expected_pass)
 
 
 @pytest.mark.parametrize(
-    "test_count, cell_count, cell_coverage, expected_ret, expected_pass", [
+    "test_count, cell_count, min_cell_coverage, expected_ret, expected_pass", [
         ( 0, 10, 50, [False], False),
         ( 5, 10, 50,  [True],  True),
         ( 0, 10,  0,  [True],  True),
         ( 0, 10, -1,      [],  True)
     ]
 )
-def test_cell_coverage(test_count, cell_count, cell_coverage, expected_ret, expected_pass):
-    metadata = {
-        'test_count': test_count,
-        'cell_count': cell_count,
-        'cell_coverage': cell_coverage
-    }
-    ret, passed = lint_cell_coverage(cell_coverage, metadata)
+def test_cell_coverage(test_count, cell_count, min_cell_coverage, expected_ret, expected_pass):
+    ret, passed = lint_cell_coverage(test_count, cell_count, min_cell_coverage)
     _verify(ret, passed, expected_ret, expected_pass)
 
 


### PR DESCRIPTION
Simplify the lint functions and add tests of lint.run(); no change in behavior.

The tests of lint.run() pass before and after this PR's changes.

To do:
  * [x] Write some tests for `lint.run()` to verify no change