### PR TITLE
Add ability to check kernelspec

### DIFF
--- a/jupyterlab_celltests/define.py
+++ b/jupyterlab_celltests/define.py
@@ -8,6 +8,7 @@ class LintType(Enum):
     CLASS_DEFINITIONS = 'class_definitions'
     CELL_COVERAGE = 'cell_coverage'
     LINTER = 'linter'
+    KERNELSPEC = 'kernelspec'
 
 
 class TestType(Enum):

--- a/jupyterlab_celltests/shared.py
+++ b/jupyterlab_celltests/shared.py
@@ -44,6 +44,7 @@ def extract_extrametadata(notebook, override=None):
     base['lines'] = 0  # TODO: is this used?
     base['functions'] = 0
     base['classes'] = 0
+    base['kernelspec'] = notebook.metadata.get('kernelspec', {})
 
     for c in notebook.cells:
         if c.get('cell_type') in ('markdown', 'raw',):


### PR DESCRIPTION
Currently, when you call `lint.run()` programmatically, you can pass a dictionary of rules - e.g. `lint.run(rules={'lines_per_cell':5, 'cells_per_notebook':5}`). This PR adds `kernelspec_requirements` as another lint rule, e.g. `lint.run({'lines_per_cell':5, 'cells_per_notebook':5, 'kernelspec_requirements': {'name':'python3'})`.

Should it be more flexible (e.g. to allow multiple possible kernel names, or a regex on kernel names, etc)?