### PR TITLE
Add basic magics handling (for counting cell, function definitions).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 jupyterlab>=1.0.0
 nbval>=0.9.1
+nbconvert
 pytest>=4.4.0
 pytest-html>=1.20.0
 flake8

--- a/tests/more.ipynb
+++ b/tests/more.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "def f1(x): x"
    ]
   },

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -98,7 +98,7 @@ def test_kernelspec(kernelspec_requirements, kernelspec, expected_ret, expected_
     # one rule, pass
     ({'lines_per_cell': -1}, [], True),
     # one rule, fail
-    ({'lines_per_cell':  1}, [True, True, True, True, False, False], False),
+    ({'lines_per_cell':  1}, [False, True, True, True, False, False], False),
     # multiple rules, combo fail
     ({'lines_per_cell':  5,
       'cells_per_notebook': 1}, [True, True, True, True, True, True, False], False),

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -37,4 +37,4 @@ def test_extract_extrametadata_cell_count_more():
     assert _metadata(MORE_NB, 'cell_count') == 6
 
 def test_extract_extrametadata_cell_lines_more():
-    assert _metadata(MORE_NB, 'cell_lines') == [1]*4 + [2,3]
+    assert _metadata(MORE_NB, 'cell_lines') == [2] + [1]*3 + [2,3]


### PR DESCRIPTION
Currently, celltests will report a syntaxerror for any notebook containing magics.

This PR allows celltests to handle magics without any problems by using nbconvert to first convert to python.

For instance, before this PR, lint checking this would result in a syntax error, but it's now fine:
```
%matplotlib inline
x = 1
```

However, counts will not always be accurate. Using nbconvert alone results in: 

1. line magics being able to mask code:

```
%time def f(): pass
```

`f` will not be counted as a function definition.

2. cell magics masking code:

```
%%capture
def f(): pass
```

`f` will not be counted as a function definition.

As far as I know, this is a limitation of nbconvert, and affects various projects in various ways. However, both those two limitations can be overcome with more sophisticated handling.

Note: adds a dependency on nbconvert (I need to check the min - probably the addition of arg to skip raw cells defines it).