### PR TITLE
Support for magics whitelist/blacklist

### DIFF
--- a/jupyterlab_celltests/define.py
+++ b/jupyterlab_celltests/define.py
@@ -9,6 +9,7 @@ class LintType(Enum):
     CELL_COVERAGE = 'cell_coverage'
     LINTER = 'linter'
     KERNELSPEC = 'kernelspec'
+    MAGICS = 'magics'
 
 
 class TestType(Enum):

--- a/jupyterlab_celltests/lint.py
+++ b/jupyterlab_celltests/lint.py
@@ -99,7 +99,7 @@ def lint_magics(magics, whitelist=None, blacklist=None):
         msg = "present in blacklist:"
 
     passed = not(bad)
-    return [LintMessage(-1, 'Checking magics ({} {})'.format(msg, bad), LintType.MAGICS, passed)], passed
+    return [LintMessage(-1, 'Checking magics{}'.format(" ({} {})".format(msg, bad) if bad else ""), LintType.MAGICS, passed)], passed
 
 
 def run(notebook, executable=None, rules=None):

--- a/jupyterlab_celltests/shared.py
+++ b/jupyterlab_celltests/shared.py
@@ -1,7 +1,9 @@
+import sys
 import ast
 import nbconvert
 
 
+# note: could consider combining these separate classes
 class FnDefCounter(ast.NodeVisitor):
     """Counts function definitions (ignoring class methods)."""
 
@@ -25,6 +27,36 @@ class ClassDefCounter(ast.NodeVisitor):
         self.count += 1
 
 
+class MagicsRecorder(ast.NodeVisitor):
+    """Record magics.
+
+    Magics are like this:
+      * get_ipython().run_line_magic(name, ...)
+      * get_ipython().run_cell_magic(name, ...)
+
+    Or this (py2):
+      * get_ipython().magic(name, ...)
+
+    """
+
+    magic_fn_names_py3 = set(['run_line_magic',
+                              'run_cell_magic'])
+    magic_fn_names_py2 = set(['magic'])
+
+    magic_fn_names = magic_fn_names_py3 | magic_fn_names_py2
+
+    def __init__(self):
+        self.seen = set()
+
+    def visit_Call(self, node):
+        if hasattr(node.func, 'attr') and node.func.attr in self.magic_fn_names:
+            if node.func.value.func.id == 'get_ipython':
+                magic_name = node.args[0].s
+                if node.func.attr in self.magic_fn_names_py2:
+                    magic_name = magic_name.split()[0]
+                self.seen.add(magic_name)
+
+
 def extract_cellsources(notebook):
     return [c['source'].split('\n') for c in notebook.cells if c.get('cell_type') == 'code']
 
@@ -33,8 +65,12 @@ def extract_celltests(notebook):
     return [c['metadata'].get('tests', []) for c in notebook.cells]
 
 
-# TODO: I think it's confusing to insert the actual counts into the metadata.
-# Why not keep them separate?
+# Note: I think it's confusing to insert the actual counts into the
+# metadata.  Why not keep them separate?
+#
+# Note: this always does everything, which might be unnecessary
+# (e.g. if haven't asked for magics checking, don't need to extract
+# them)
 def extract_extrametadata(notebook, override=None):
     base = notebook.metadata.get('celltests', {})
     override = override or {}
@@ -44,7 +80,9 @@ def extract_extrametadata(notebook, override=None):
     # "python code" things (e.g. number of function definitions)...
     # note: no attempt to be clever here (so e.g. "%time def f: pass" would be missed, as would the contents of
     # a cell using %%capture cell magics; possible to handle those scenarios but would take more effort)
-    parsed_source = ast.parse(nbconvert.PythonExporter(exclude_raw=True).from_notebook_node(notebook)[0])
+    code = nbconvert.PythonExporter(exclude_raw=True).from_notebook_node(notebook)[0]
+    # notebooks start with "coding: utf-8"
+    parsed_source = ast.parse(code.encode('utf8') if sys.version_info[0] == 2 else code)
 
     fn_def_counter = FnDefCounter()
     fn_def_counter.visit(parsed_source)
@@ -53,6 +91,12 @@ def extract_extrametadata(notebook, override=None):
     class_counter = ClassDefCounter()
     class_counter.visit(parsed_source)
     base['classes'] = class_counter.count
+
+    # alternative to doing it this way would be to check the ipython
+    # souce for %magic, %%magics before it's converted to regular python
+    magics_recorder = MagicsRecorder()
+    magics_recorder.visit(parsed_source)
+    base['magics'] = magics_recorder.seen
 
     # "notebook structure" things...
     base['cell_count'] = 0

--- a/jupyterlab_celltests/shared.py
+++ b/jupyterlab_celltests/shared.py
@@ -31,11 +31,11 @@ class MagicsRecorder(ast.NodeVisitor):
     """Record magics.
 
     Magics are like this:
-      * get_ipython().run_line_magic(name, ...)
-      * get_ipython().run_cell_magic(name, ...)
+      * get_ipython().run_line_magic(name, line)
+      * get_ipython().run_cell_magic(name, line, cell)
 
     Or this (py2):
-      * get_ipython().magic(name, ...)
+      * get_ipython().magic(magic_string)
 
     """
 
@@ -50,10 +50,11 @@ class MagicsRecorder(ast.NodeVisitor):
 
     def visit_Call(self, node):
         if hasattr(node.func, 'attr') and node.func.attr in self.magic_fn_names:
+            # should maybe find ipython's own parsing code and use that instead
             if node.func.value.func.id == 'get_ipython':
                 magic_name = node.args[0].s
                 if node.func.attr in self.magic_fn_names_py2:
-                    magic_name = magic_name.split()[0]
+                    magic_name = magic_name.split()[0]  # (again, find ipython's parsing?)
                 self.seen.add(magic_name)
 
 

--- a/tests/magics.ipynb
+++ b/tests/magics.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%magics1 inline\n",
+    "def f1(x): x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%magics2 def f1(x): x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%magics3\n",
+    "def f2(x): x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\"\"\"\n",
+    "%magics4 inline\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "%magics5 inline"
+   ]
+  }  
+],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -7,7 +7,7 @@ from jupyterlab_celltests.shared import extract_extrametadata
 
 BASIC_NB = os.path.join(os.path.dirname(__file__), 'basic.ipynb')
 MORE_NB = os.path.join(os.path.dirname(__file__), 'more.ipynb')
-
+MAGICS_NB = os.path.join(os.path.dirname(__file__), 'magics.ipynb')
 
 def _metadata(nb, what):
     extra_metadata = extract_extrametadata(nbformat.read(nb, 4))
@@ -38,3 +38,7 @@ def test_extract_extrametadata_cell_count_more():
 
 def test_extract_extrametadata_cell_lines_more():
     assert _metadata(MORE_NB, 'cell_lines') == [2] + [1]*3 + [2,3]
+
+
+def test_extract_extrametadata_magics():
+    assert _metadata(MAGICS_NB, 'magics') == set(['magics1', 'magics2', 'magics3'])


### PR DESCRIPTION
Allow optional specification of either a whitelist of acceptable magics, or a blacklist of unacceptable magics (but not both). 

Specifying a whitelist restricts to only those entries (an empty whitelist denying all magics), while specifying a blacklist rejects any of those entries.

The existing default behavior (any magic's acceptable) is unchanged.

## More details

Currently, when you call `lint.run()` programmatically, you can pass a dictionary of rules - e.g.

```
>>> import jupyterlab_celltests.lint as lint
>>> lint.run("tests/more.ipynb",rules={'cells_per_notebook':20})
([PASSED: Checking cells per notebook (max=20; actual=6) (Notebook)], True)
```

This PR adds `magics_whitelist` or `magics_blacklist` as an optional lint rule, e.g. 

```
>>> import jupyterlab_celltests.lint as lint
>>> lint.run("tests/more.ipynb",rules={'magics_blacklist':['matplotlib']})
([FAILED: Checking magics (present in blacklist: {'matplotlib'}) (Notebook)], False)
>>> lint.run("tests/more.ipynb",rules={'magics_whitelist':['matplotlib']})
([PASSED: Checking magics (Notebook)], True)
>>> lint.run("tests/more.ipynb",rules={'magics_whitelist':[]})
([FAILED: Checking magics (missing from whitelist: {'matplotlib'}) (Notebook)], False)
lint.run("tests/more.ipynb",rules={'magics_whitelist':['one'], 'magics_blacklist':['two']})
Traceback (most recent call last):
[...]
ValueError: Must specify either a whitelist or a blacklist, not both. Blacklist: ['two']; whitelist: ['one']
```

## Notes

  * _Should_ work on py2, but don't think that is being tested on CI.
  * It could be possible to do this cell by cell (to get cell numbers), but it would be more work.

## Alternative approaches
  * Check the original source for magics (in the form %magic or %%magic), e.g. by regex.
  * (let me know if there's a better way I didn't consider!)