### PR TITLE
Miscellaneous packaging improvements (including python packages stored as azure artifacts)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,11 @@ js:  ## build javascript
 labextension: js ## enable labextension
 	jupyter labextension install .
 
-dist: js  ## dist to pypi
+dist: js
 	rm -rf dist build
-	python3.7 setup.py sdist
-	python3.7 setup.py bdist_wheel
+	python3.7 setup.py sdist bdist_wheel
+
+publish: dist  ## dist to pypi
 	twine check dist/* && twine upload dist/*
 	npm publish
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,7 +52,8 @@ jobs:
         summaryFileLocation: '$(System.DefaultWorkingDirectory)/*coverage.xml'
 
     - script: |
-        python -m pip install twine
+        # duplicates pyproject.toml; see https://github.com/pypa/pip/issues/6041 etc etc etc...
+        python -m pip install wheel setuptools jupyter-packaging twine
         make dist
       displayName: 'Create packages'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,12 +58,11 @@ jobs:
 
     - task: TwineAuthenticate@0
       inputs:
-        artifactFeeds: TODOproj/TODOfeed
-        externalFeeds: pypi
+        artifactFeeds: jupyter/python-packages
 
     # just python for now; should be able to use "make publish" eventually
     - script: |
-        twine check dist/* && twine upload -r TODOfeed --config-file $(PYPIRC_PATH) dist/*
+        twine check dist/* && twine upload -r python-packages --config-file $(PYPIRC_PATH) dist/*
       displayName: 'Upload packages'
 
 - job: 'Mac'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
 
     # just python for now; should be able to use "make publish" eventually
     - script: |
-        twine check dist/* && twine upload -r python-packages --config-file $(PYPIRC_PATH) dist/*
+        twine check dist/* && twine upload -r python-packages/pypi/upload --config-file $(PYPIRC_PATH) dist/*
       displayName: 'Upload packages'
 
 - job: 'Mac'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,9 +66,6 @@ jobs:
         twine check dist/* && twine upload -r TODOfeed --config-file $(PYPIRC_PATH) dist/*
       displayName: 'Upload packages'
 
-
-- script:
-
 - job: 'Mac'
   pool:
     vmImage: 'macos-10.14'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
 
     # just python for now; should be able to use "make publish" eventually
     - script: |
-        twine check dist/* && twine upload -r python-packages/pypi/upload --config-file $(PYPIRC_PATH) dist/*
+        twine check dist/* && twine upload -r jupyter/python-packages --config-file $(PYPIRC_PATH) dist/*
       displayName: 'Upload packages'
 
 - job: 'Mac'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,9 +47,27 @@ jobs:
         testRunTitle: 'Publish test results for Python $(python.version) $(manylinux_flag)'
 
     - task: PublishCodeCoverageResults@1
-      inputs: 
+      inputs:
         codeCoverageTool: Cobertura
         summaryFileLocation: '$(System.DefaultWorkingDirectory)/*coverage.xml'
+
+    - script: |
+        python -m pip install twine
+        make dist
+      displayName: 'Create packages'
+
+    - task: TwineAuthenticate@0
+      inputs:
+        artifactFeeds: TODOproj/TODOfeed
+        externalFeeds: pypi
+
+    # just python for now; should be able to use "make publish" eventually
+    - script: |
+        twine check dist/* && twine upload -r TODOfeed --config-file $(PYPIRC_PATH) dist/*
+      displayName: 'Upload packages'
+
+
+- script:
 
 - job: 'Mac'
   pool:
@@ -96,7 +114,7 @@ jobs:
         testRunTitle: 'Publish test results for Python $(python.version) $(manylinux_flag)'
 
     - task: PublishCodeCoverageResults@1
-      inputs: 
+      inputs:
         codeCoverageTool: Cobertura
         summaryFileLocation: '$(System.DefaultWorkingDirectory)/*coverage.xml'
 
@@ -153,6 +171,6 @@ jobs:
         testRunTitle: 'Publish test results for Python $(python.version) $(manylinux_flag)'
 
     - task: PublishCodeCoverageResults@1
-      inputs: 
+      inputs:
         codeCoverageTool: Cobertura
         summaryFileLocation: '$(System.DefaultWorkingDirectory)/*coverage.xml'

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ from jupyter_packaging import (
 
 pjoin = path.join
 
-ensure_python('>=3.6')
-
 name = 'jupyterlab_celltests'
 here = path.abspath(path.dirname(__file__))
 version = get_version(pjoin(here, name, '_version.py'))

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     version=version,
     description='Cell-by-cell tests for JupyterLab',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/timkpaine/jupyterlab_celltests',
     author='Tim Paine',
     author_email='t.paine154@gmail.com',


### PR DESCRIPTION
## Changes

  * setup.py: Don't prevent people from installing on python 2.7 (even though not all of celltests will work on python 2.7)
  * setup.py: fix long description content type (display md on pypi).
  * Makefile: Split up package creation and upload.
  * Azure pipeline: Build python packages and store as azure artifacts.

## Azure artifacts

Packages get uploaded to a feed from the linux build:

![Screenshot from 2020-03-05 21-57-22](https://user-images.githubusercontent.com/1929/76029449-64a5ab00-5f2c-11ea-9878-13bdda15a853.png)

That's available as https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/

I was able to install the azure artifact into a clean environment:

```
$ pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ jupyterlab_celltests --extra-index-url=https://pypi.org/simple
Looking in indexes: https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/, https://pypi.org/simple
Collecting jupyterlab_celltests
  Downloading https://pkgs.dev.azure.com/tpaine154/08a6689e-e968-49ca-8463-10c013e599d1/_packaging/2f7d1a9d-b84c-4325-ba2d-92ff76ce17f0/pypi/download/jupyterlab-celltests/0.1.2/jupyterlab_celltests-0.1.2-py2.py3-none-any.whl (31 kB)
Collecting pytest-html>=1.20.0
  Downloading pytest_html-2.0.1-py2.py3-none-any.whl (15 kB)
Collecting flake8
  Downloading flake8-3.7.9-py2.py3-none-any.whl (69 kB)
     |████████████████████████████████| 69 kB 2.1 MB/s 
Collecting jupyterlab>=1.0.0
  Downloading jupyterlab-2.0.0-py2.py3-none-any.whl (7.7 MB)
     |████████████████████████████████| 7.7 MB 1.4 MB/s
[...]
  Created wheel for backcall: filename=backcall-0.1.0-py3-none-any.whl size=10413 sha256=5f602f7b978de8626c54fbcef09d381e0f6ead5f36cb02b5c7e5002965cbaa35
  Stored in directory: /home/sefkw/.cache/pip/wheels/9e/56/4f/da13e448a8a5b8671b2954600d5355cf36e557c7aa5020139b
Successfully built tornado prometheus-client pyrsistent pandocfilters backcall
Installing collected packages: attrs, zipp, importlib-metadata, pluggy, six, pyparsing, packaging, py, more-itertools, wcwidth, pytest, pytest-metadata, pytest-html, pycodestyle, mccabe, entrypoints, pyflakes, flake8, pyrsistent, jsonschema, json5, MarkupSafe, jinja2, ipython-genutils, decorator, traitlets, jupyter-core, testpath, mistune, webencodings, bleach, pygments, pandocfilters, defusedxml, nbformat, nbconvert, tornado, prometheus-client, python-dateutil, pyzmq, jupyter-client, ptyprocess, terminado, Send2Trash, pickleshare, parso, jedi, prompt-toolkit, pexpect, backcall, ipython, ipykernel, notebook, jupyterlab-server, jupyterlab, coverage, nbval, jupyterlab-celltests
Successfully installed MarkupSafe-1.1.1 Send2Trash-1.5.0 attrs-19.3.0 backcall-0.1.0 bleach-3.1.1 coverage-5.0.3 decorator-4.4.2 defusedxml-0.6.0 entrypoints-0.3 flake8-3.7.9 importlib-metadata-1.5.0 ipykernel-5.1.4 ipython-7.13.0 ipython-genutils-0.2.0 jedi-0.16.0 jinja2-2.11.1 json5-0.9.2 jsonschema-3.2.0 jupyter-client-6.0.0 jupyter-core-4.6.3 jupyterlab-2.0.0 jupyterlab-celltests-0.1.2 jupyterlab-server-1.0.7 mccabe-0.6.1 mistune-0.8.4 more-itertools-8.2.0 nbconvert-5.6.1 nbformat-5.0.4 nbval-0.9.5 notebook-6.0.3 packaging-20.3 pandocfilters-1.4.2 parso-0.6.2 pexpect-4.8.0 pickleshare-0.7.5 pluggy-0.13.1 prometheus-client-0.7.1 prompt-toolkit-3.0.3 ptyprocess-0.6.0 py-1.8.1 pycodestyle-2.5.0 pyflakes-2.1.1 pygments-2.5.2 pyparsing-2.4.6 pyrsistent-0.15.7 pytest-5.3.5 pytest-html-2.0.1 pytest-metadata-1.8.0 python-dateutil-2.8.1 pyzmq-19.0.0 six-1.14.0 terminado-0.8.3 testpath-0.4.4 tornado-6.0.4 traitlets-4.3.3 wcwidth-0.1.8 webencodings-0.5.1 zipp-3.1.0
```

## Future work

  * Repeat for npm.
  * Might need to configure artifact retention policy or similar.
  * Consider having the versioning update automatically (e.g. based on git, or build number, or whatever you prefer), so that the packages from the feed do not misleadingly claim to be the release version (they should only claim that when they are the packages that will be uploaded to pypi).