### PR TITLE
Improvements to release procedure

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = (0, 1, 2, 'final', 0)
-commit = False
+commit = True
 tag = True
 tag_name = v{new_major}.{new_minor}.{new_patch}{new_release}{new_build}
 parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,14 +1,15 @@
 [bumpversion]
 current_version = (0, 1, 2, 'final', 0)
 commit = False
-tag = False
+tag = True
+tag_name = v{new_major}.{new_minor}.{new_patch}{new_release}{new_build}
 parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)
-serialize = 
+serialize =
 	{major}, {minor}, {patch}, '{release}', {build}
 
 [bumpversion:part:release]
 optional_value = final
-values = 
+values =
 	alpha
 	candidate
 	final
@@ -17,3 +18,9 @@ values =
 
 [bumpversion:file:jupyterlab_celltests/_version.py]
 
+[bumpversion:file:package.json]
+search = "version": "{current_version}"
+replace = "version": "{new_version}"
+serialize =
+	  {major}.{minor}.{patch}-{release}.{build}
+	  {major}.{minor}.{patch}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,15 @@ Once you have such a development setup, you should:
 - If you add new code, preferably write one or more tests for checking that your code works as expected.
 - Commit your changes and publish the branch to your github repo.
 - Open a pull-request (PR) back to the main repo on Github.
+
+# Releasing
+
+To make a new release of jupyterlab_celltests:
+
+1. `bumpversion patch` (replacing `patch` with whatever is appropriate for the current release) - this will also create a tag.
+2. `git push --tags` - this will trigger a package build on azure, and upload to https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages
+3. Check the resulting package:
+  - Install and test it in a clean environment (you can install with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ jupyterlab_celltests --extra-index-url=https://pypi.org/simple` (modifying as appropriate to use the wheel or the sdist).
+  - Inspect the sdist and wheel to make sure they contain the right files, version numbers, etc.
+4. Once satisfied, `bumpversion release` until "final" and then grab the resulting release from azure and upload to pypi.
+5. TODO: I haven't covered the npm side yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,10 @@ Once you have such a development setup, you should:
 
 To make a new release of jupyterlab_celltests:
 
-1. `bumpversion patch` (replacing `patch` with whatever is appropriate for the current release) - this will also create a tag.
-2. `git push --tags` - this will trigger a package build on azure, and upload to https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages
+1. `bumpversion patch` (replacing `patch` with whatever is appropriate for the current release) - This will also create a git tag.
+2. `git push --tags` - This will trigger a package build on azure, and upload to [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages).
 3. Check the resulting package:
-  - Install and test it in a clean environment (you can install with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ jupyterlab_celltests --extra-index-url=https://pypi.org/simple` (modifying as appropriate to use the wheel or the sdist).
+  - Install and test it in a clean environment (you can install with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ jupyterlab_celltests --extra-index-url=https://pypi.org/simple`, modifying as appropriate to use the wheel or the sdist).
   - Inspect the sdist and wheel to make sure they contain the right files, version numbers, etc.
 4. Once satisfied, `bumpversion release` until "final" and then grab the resulting release from azure and upload to pypi.
 5. TODO: I haven't covered the npm side yet.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,12 @@ Once you have such a development setup, you should:
 
 To make a new release of jupyterlab_celltests:
 
-1. `bumpversion patch` (replacing `patch` with whatever is appropriate for the current release) - This will also create a git tag.
-2. `git push --tags` - This will trigger a package build on azure, and upload to [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages).
-3. Check the resulting package:
-  - Install and test it in a clean environment (you can install with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ jupyterlab_celltests --extra-index-url=https://pypi.org/simple`, modifying as appropriate to use the wheel or the sdist).
-  - Inspect the sdist and wheel to make sure they contain the right files, version numbers, etc.
-4. Once satisfied, `bumpversion release` until "final" and then grab the resulting release from azure and upload to pypi.
-5. TODO: I haven't covered the npm side yet.
+1. `bumpversion patch` (replacing `patch` with whatever is appropriate for the current release, e.g. `minor`, `major`, etc) - This will also create a git commit and tag.
+2. `git push --tags` - This will trigger python and npm package builds on azure, and upload to [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages).
+3. Check the resulting packages:
+  - Install and test in a clean environment:
+    - You can install for python with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ jupyterlab_celltests --extra-index-url=https://pypi.org/simple`, modifying as appropriate to use the wheel or the sdist.
+    - TODO npm
+  - Inspect the sdist, wheel, and npm tgz to make sure they contain the right files, version numbers, etc.
+4. Once satisfied, `bumpversion release` until "final", and then grab the resulting release from azure and upload to pypi and npm.
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,11 +67,20 @@ jobs:
       inputs:
         artifactFeeds: jupyter/python-packages
 
-    # just python for now; should be able to use "make publish" eventually
     - script: |
         twine check dist/* && twine upload -r jupyter/python-packages --config-file $(PYPIRC_PATH) dist/*
       displayName: 'Upload packages'
       condition: contains(variables['Build.SourceBranch'], 'tags')  # todo: match "release" style tags only (v...)
+
+#    - task: npmAuthenticate@0
+#      inputs:
+#        artifactFeeds: jupyter/python-packages
+
+    - task: Npm@1
+      inputs:
+        command: publish
+        publishRegistry: useFeed
+        publishFeed: jupyter/python-packages
 
 - job: 'Mac'
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,15 +72,12 @@ jobs:
       displayName: 'Upload packages'
       condition: contains(variables['Build.SourceBranch'], 'tags')  # todo: match "release" style tags only (v...)
 
-#    - task: npmAuthenticate@0
-#      inputs:
-#        artifactFeeds: jupyter/python-packages
-
     - task: Npm@1
       inputs:
         command: publish
         publishRegistry: useFeed
         publishFeed: jupyter/python-packages
+      condition: contains(variables['Build.SourceBranch'], 'tags')  # todo: match "release" style tags only (v...)
 
 - job: 'Mac'
   pool:

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     packages=find_packages(exclude=['tests', ]),
     install_requires=requires,
     extras_require={
-        'dev': ['bumpversion',
+        'dev': ['bump2version', # bumpversion won't make the right git tag
                 'autopep8',
                 'pytest-cov>=2.6.1',
                 'mock']


### PR DESCRIPTION
* Add package.json to files managed by bumpversion.
* Have bumpversion do the git tagging (requires [bump2version](https://pypi.org/project/bump2version/))
* npm package creation and upload to feed (on tag, as was done for python)
* Proposal for how to do releases (see CONTRIBUTING.md)

Questions:
  * [ ] Should we manage package.json with bumpversion (lockstep with python package?)
  * [ ] What do you think about the changed bumpversion workflow?
  * [ ] If keeping the workflow, are we happy with the release names/flow (alpha, candidate, final)?

## npm publish

![Screenshot from 2020-03-06 13-47-50](https://user-images.githubusercontent.com/1929/76089203-27373100-5fb1-11ea-8428-cd46bcd50d24.png)

## bumpversion usage

Now it commits, tags, and updates package.json...
```
$ git tag -l
[...]
v0.1.2

$ bump2version patch

$ head .bumpversion.cfg package.json 
==> .bumpversion.cfg <==
[bumpversion]
current_version = 0, 1, 3, 'alpha', 0
commit = True
tag = True
tag_name = v{new_major}.{new_minor}.{new_patch}{new_release}{new_build}
parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)
serialize = 
	{major}, {minor}, {patch}, '{release}', {build}

[bumpversion:part:release]

==> package.json <==
{
  "name": "jupyterlab_celltests",
  "version": "0.1.3-alpha.0",
  "description": "A JupyterLab extension.",
  "author": "Tim Paine",
  "main": "lib/index.js",
  "license": "Apache-2.0",
  "keywords": [
    "jupyter",
    "jupyterlab",

$ git tag -l
[...]
v0.1.2
v0.1.3alpha0

$ git log -1
commit dbf45f552185815a4b6479c22edf0f13193a5c95 (HEAD -> more_pkg_improvements, tag: v0.1.3alpha0)
Author: Chris B <ceball@users.sf.net>
Date:   Fri Mar 6 13:54:57 2020 +0000

    Bump version: (0, 1, 2, 'final', 0) → 0, 1, 3, 'alpha', 0
```

(jupyterlab_celltests/_version - not shown above - is changed in the same way as before)

Increment release:

```
$ bump2version release

$ head .bumpversion.cfg package.json 
==> .bumpversion.cfg <==
[bumpversion]
current_version = 0, 1, 3, 'candidate', 0
commit = True
tag = True
tag_name = v{new_major}.{new_minor}.{new_patch}{new_release}{new_build}
parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)
serialize = 
	{major}, {minor}, {patch}, '{release}', {build}

[bumpversion:part:release]

==> package.json <==
{
  "name": "jupyterlab_celltests",
  "version": "0.1.3-candidate.0",
  "description": "A JupyterLab extension.",
  "author": "Tim Paine",
  "main": "lib/index.js",
  "license": "Apache-2.0",
  "keywords": [
    "jupyter",
    "jupyterlab",

$ git tag -l
[...]
v0.1.2
v0.1.3alpha0
v0.1.3candidate0

$ git log -1
commit cfd19dc19a510cf5bba243c41e7b57ce1cb1daed (HEAD -> more_pkg_improvements, tag: v0.1.3candidate0)
Author: Chris B <ceball@users.sf.net>
Date:   Fri Mar 6 13:57:11 2020 +0000

    Bump version: 0, 1, 3, 'alpha', 0 → 0, 1, 3, 'candidate', 0
```

Increment release again:

```
$ bump2version release

$ head .bumpversion.cfg package.json 
==> .bumpversion.cfg <==
[bumpversion]
current_version = 0, 1, 3, 'final', 0
commit = True
tag = True
tag_name = v{new_major}.{new_minor}.{new_patch}{new_release}{new_build}
parse = (?P<major>\d+)\,\ (?P<minor>\d+)\,\ (?P<patch>\d+)\,\ \'(?P<release>\S+)\'\,\ (?P<build>\d+)
serialize = 
	{major}, {minor}, {patch}, '{release}', {build}

[bumpversion:part:release]

==> package.json <==
{
  "name": "jupyterlab_celltests",
  "version": "0.1.3",
  "description": "A JupyterLab extension.",
  "author": "Tim Paine",
  "main": "lib/index.js",
  "license": "Apache-2.0",
  "keywords": [
    "jupyter",
    "jupyterlab",

$ git log -1
commit 04304b25bf8ecd8ba8cb8dc57afcdaf5fa4ad099 (HEAD -> more_pkg_improvements, tag: v0.1.3final0)
Author: Chris B <ceball@users.sf.net>
Date:   Fri Mar 6 13:57:48 2020 +0000

    Bump version: 0, 1, 3, 'candidate', 0 → 0, 1, 3, 'final', 0

$ git tag -l
[...]
v0.1.2
v0.1.3alpha0
v0.1.3candidate0
v0.1.3final0
```

Note that release ('final') and build no. are not present in package.json for 'final' releases. 