### PR TITLE
Instructions for installing labextension from azure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,6 @@ To make a new release of jupyterlab_celltests:
 3. Check the resulting packages:
   - Install and test in a clean environment:
     - You can install for python with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ jupyterlab_celltests==0.1.3a0 --extra-index-url=https://pypi.org/simple`, modifying as appropriate to use the wheel or the sdist, and to install the version you want to test.
-    - Download the jupyterlab_celltests npm package from https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages and then install with `jupyter labextension install /path/to/jupyterlab_celltests-0.1.3-alpha.0.tgz` (replacing the filename with whatever you downloaded).
+    - Download the jupyterlab_celltests npm package from [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages) and then install with `jupyter labextension install /path/to/jupyterlab_celltests-0.1.3-alpha.0.tgz` (replacing the filename with whatever you downloaded).
   - Inspect the sdist, wheel, and npm tgz to make sure they contain the right files, version numbers, etc.
 4. Once satisfied, use `bumpversion` either to set or increment `release` to `final` (e.g.  `bumpversion release`), and then grab the resulting releases from azure and upload to pypi and npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,7 @@ To make a new release of jupyterlab_celltests:
 2. `git push --follow-tags` - This will trigger python and npm package builds on azure, and upload to [our azure feed](https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages).
 3. Check the resulting packages:
   - Install and test in a clean environment:
-    - You can install for python with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ jupyterlab_celltests --extra-index-url=https://pypi.org/simple`, modifying as appropriate to use the wheel or the sdist.
-    - TODO npm
+    - You can install for python with `pip install --index-url=https://pkgs.dev.azure.com/tpaine154/jupyter/_packaging/python-packages/pypi/simple/ jupyterlab_celltests==0.1.3a0 --extra-index-url=https://pypi.org/simple`, modifying as appropriate to use the wheel or the sdist, and to install the version you want to test.
+    - Download the jupyterlab_celltests npm package from https://dev.azure.com/tpaine154/jupyter/_packaging?_a=feed&feed=python-packages and then install with `jupyter labextension install /path/to/jupyterlab_celltests-0.1.3-alpha.0.tgz` (replacing the filename with whatever you downloaded).
   - Inspect the sdist, wheel, and npm tgz to make sure they contain the right files, version numbers, etc.
-4. Once satisfied, `bumpversion release` until "final", and then grab the resulting release from azure and upload to pypi and npm.
-
+4. Once satisfied, use `bumpversion` either to set or increment `release` to `final` (e.g.  `bumpversion release`), and then grab the resulting releases from azure and upload to pypi and npm.

--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,11 @@ js:  ## build javascript
 labextension: js ## enable labextension
 	jupyter labextension install .
 
-dist: js
+dist: js  ## create dists
 	rm -rf dist build
 	python3.7 setup.py sdist bdist_wheel
 
-publish: dist  ## dist to pypi
+publish: dist  ## dist to pypi and npm
 	twine check dist/* && twine upload dist/*
 	npm publish
 


### PR DESCRIPTION
How to download and install labextension from azure. No idea how to find the direct download link on azure. Otherwise, could just `jupyter labextension install https://azure-link/jupyterlab_celltests-0.1.3-alpha.0.tgz` or whatever.

Also: add missing docs to Makefile.